### PR TITLE
support for custom hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,11 @@ Ngrok::Tunnel.stop
 
 ```ruby
 # ngrok custom parameters
-Ngrok::Tunnel.start(port: 3333, 
-                    subdomain: 'MY_SUBDOMAIN', 
-                    authtoken: 'MY_TOKEN', 
-                    log: 'ngrok.log', 
+Ngrok::Tunnel.start(port: 3333,
+                    subdomain: 'MY_SUBDOMAIN',
+                    hostname: 'MY_HOSTNAME',
+                    authtoken: 'MY_TOKEN',
+                    log: 'ngrok.log',
                     config: '~/.ngrok')
 
 ```

--- a/lib/ngrok/tunnel.rb
+++ b/lib/ngrok/tunnel.rb
@@ -75,6 +75,7 @@ module Ngrok
         exec_params = "-log=stdout -log-level=debug "
         exec_params << "-authtoken=#{@params[:authtoken]} " if @params[:authtoken]
         exec_params << "-subdomain=#{@params[:subdomain]} " if @params[:subdomain]
+        exec_params << "-hostname=#{@params[:hostname]} " if @params[:hostname]
         exec_params << "-config=#{@params[:config]} #{@params[:port].to_i} > #{@params[:log].path}"
       end
 

--- a/spec/tunnel/tunnel_spec.rb
+++ b/spec/tunnel/tunnel_spec.rb
@@ -2,7 +2,7 @@
 describe Ngrok::Tunnel do
 
   describe "Before start" do
-    
+
     it "should not be running" do
       expect(Ngrok::Tunnel.running?).to be false
     end
@@ -72,6 +72,16 @@ describe Ngrok::Tunnel do
 
     it "should fail with incorrect authtoken" do
       expect {Ngrok::Tunnel.start(subdomain: 'test-subdomain', authtoken: 'incorrect_token')}.to raise_error
+    end
+  end
+
+  describe "Custom hostname" do
+    it "should fail without authtoken" do
+      expect {Ngrok::Tunnel.start(hostname: 'example.com')}.to raise_error
+    end
+
+    it "should fail with incorrect authtoken" do
+      expect {Ngrok::Tunnel.start(hostname: 'example.com', authtoken: 'incorrect_token')}.to raise_error
     end
   end
 


### PR DESCRIPTION
We have custom CNAME pointed to ngrok.io servers and would like to use them. So, exposing the `-hostname=[host]` option from the passed-in params.