### PR TITLE
Support remote addresses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 *.o
 *.a
 mkmf.log
+test.log

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Ngrok::Tunnel.stop
 
 ```ruby
 # ngrok custom parameters
-Ngrok::Tunnel.start(port: 3333,
+Ngrok::Tunnel.start(addr: 3333,
                     subdomain: 'MY_SUBDOMAIN',
                     hostname: 'MY_HOSTNAME',
                     authtoken: 'MY_TOKEN',

--- a/lib/ngrok/tunnel.rb
+++ b/lib/ngrok/tunnel.rb
@@ -13,6 +13,9 @@ module Ngrok
       attr_reader :pid, :ngrok_url, :ngrok_url_https, :status
 
       def init(params = {})
+        # map old key 'port' to 'addr' to maintain backwards compatibility with versions 2.0.21 and earlier
+        params[:addr] = params.delete(:port) if params.key?(:port)
+
         @params = {addr: 3001, timeout: 10, config: '/dev/null'}.merge(params)
         @status = :stopped unless @status
       end
@@ -51,6 +54,11 @@ module Ngrok
 
       def addr
         @params[:addr]
+      end
+
+      def port
+        return addr if addr.is_a?(Numeric)
+        addr.split(":").last.to_i
       end
 
       def log

--- a/lib/ngrok/tunnel.rb
+++ b/lib/ngrok/tunnel.rb
@@ -13,7 +13,7 @@ module Ngrok
       attr_reader :pid, :ngrok_url, :ngrok_url_https, :status
 
       def init(params = {})
-        @params = {port: 3001, timeout: 10, config: '/dev/null'}.merge(params)
+        @params = {addr: 3001, timeout: 10, config: '/dev/null'}.merge(params)
         @status = :stopped unless @status
       end
 
@@ -49,8 +49,8 @@ module Ngrok
         @status == :stopped
       end
 
-      def port
-        @params[:port]
+      def addr
+        @params[:addr]
       end
 
       def log
@@ -77,7 +77,7 @@ module Ngrok
         exec_params << "-subdomain=#{@params[:subdomain]} " if @params[:subdomain]
         exec_params << "-hostname=#{@params[:hostname]} " if @params[:hostname]
         exec_params << "-inspect=#{@params[:inspect]} " if @params.has_key? :inspect
-        exec_params << "-config=#{@params[:config]} #{@params[:port].to_i} > #{@params[:log].path}"
+        exec_params << "-config=#{@params[:config]} #{@params[:addr]} > #{@params[:log].path}"
       end
 
       def fetch_urls

--- a/spec/tunnel/tunnel_spec.rb
+++ b/spec/tunnel/tunnel_spec.rb
@@ -1,4 +1,3 @@
-
 describe Ngrok::Tunnel do
 
   describe "Before start" do
@@ -37,8 +36,8 @@ describe Ngrok::Tunnel do
       expect(Ngrok::Tunnel.status).to eq :running
     end
 
-    it "should match local_port" do
-      expect(Ngrok::Tunnel.port).to eq(3001)
+    it "should match local_addr" do
+      expect(Ngrok::Tunnel.addr).to eq(3001)
     end
 
     it "should have valid ngrok_url" do
@@ -82,6 +81,15 @@ describe Ngrok::Tunnel do
 
     it "should fail with incorrect authtoken" do
       expect {Ngrok::Tunnel.start(hostname: 'example.com', authtoken: 'incorrect_token')}.to raise_error
+    end
+  end
+
+  describe "Custom addr" do
+    it "should support remote addresses" do
+      addr = '192.168.0.5:10010'
+      Ngrok::Tunnel.start(addr: addr)
+      expect(Ngrok::Tunnel.addr).to eq addr
+      Ngrok::Tunnel.stop
     end
   end
 

--- a/spec/tunnel/tunnel_spec.rb
+++ b/spec/tunnel/tunnel_spec.rb
@@ -36,6 +36,10 @@ describe Ngrok::Tunnel do
       expect(Ngrok::Tunnel.status).to eq :running
     end
 
+    it "should still support port" do
+      expect(Ngrok::Tunnel.port).to eq(3001)
+    end
+
     it "should match local_addr" do
       expect(Ngrok::Tunnel.addr).to eq(3001)
     end
@@ -66,25 +70,39 @@ describe Ngrok::Tunnel do
 
   describe "Custom subdomain" do
     it "should fail without authtoken" do
-      expect {Ngrok::Tunnel.start(subdomain: 'test-subdomain')}.to raise_error
+      expect {Ngrok::Tunnel.start(subdomain: 'test-subdomain')}.to raise_error Ngrok::Error
     end
 
     it "should fail with incorrect authtoken" do
-      expect {Ngrok::Tunnel.start(subdomain: 'test-subdomain', authtoken: 'incorrect_token')}.to raise_error
+      expect {Ngrok::Tunnel.start(subdomain: 'test-subdomain', authtoken: 'incorrect_token')}.to raise_error Ngrok::Error
     end
   end
 
   describe "Custom hostname" do
     it "should fail without authtoken" do
-      expect {Ngrok::Tunnel.start(hostname: 'example.com')}.to raise_error
+      expect {Ngrok::Tunnel.start(hostname: 'example.com')}.to raise_error Ngrok::Error
     end
 
     it "should fail with incorrect authtoken" do
-      expect {Ngrok::Tunnel.start(hostname: 'example.com', authtoken: 'incorrect_token')}.to raise_error
+      expect {Ngrok::Tunnel.start(hostname: 'example.com', authtoken: 'incorrect_token')}.to raise_error Ngrok::Error
     end
   end
 
   describe "Custom addr" do
+    it "should map port param to addr" do
+      port = 10010
+      Ngrok::Tunnel.start(port: port)
+      expect(Ngrok::Tunnel.addr).to eq port
+      Ngrok::Tunnel.stop
+    end
+
+    it "should return just the port when the address contains a host" do
+      addr = '192.168.0.5:10010'
+      Ngrok::Tunnel.start(addr: addr)
+      expect(Ngrok::Tunnel.port).to eq 10010
+      Ngrok::Tunnel.stop
+    end
+
     it "should support remote addresses" do
       addr = '192.168.0.5:10010'
       Ngrok::Tunnel.start(addr: addr)


### PR DESCRIPTION
ngrok supports forwarding to servers on a different machine (non-local services), so I updated the port parameter to be an addr parameter.
