### PR TITLE
Add support for leaving an ngrok process open and reusing an existing ngrok process instead of starting a new one on every process.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,9 @@ Ngrok::Tunnel.start(addr: 'foo.dev:80',
                     authtoken: 'MY_TOKEN',
                     inspect: false,
                     log: 'ngrok.log',
-                    config: '~/.ngrok')
+                    config: '~/.ngrok',
+                    persistence, true,
+                    persistence_file: '/tmp/ngrok-process')
 
 ```
 


### PR DESCRIPTION
I needed my ngrok process to persist across multiple Ruby processes so that I could test web service callbacks in a multiprocess environment without a constantly changing ngrok hostname.

On initial start, it saves the details of the running process to a file.   On subsequent starts, it then reads that file, verifies that the process still running, and then uses it instead of running a new process.
