### PR TITLE
Fixed ngrok persistence support PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,9 @@ Ngrok::Tunnel.start(addr: 'foo.dev:80',
                     authtoken: 'MY_TOKEN',
                     inspect: false,
                     log: 'ngrok.log',
-                    config: '~/.ngrok')
+                    config: '~/.ngrok',
+                    persistence: true,
+                    persistence_file: '/tmp/ngrok-process') # optional parameter
 
 ```
 


### PR DESCRIPTION
This is a second stab at enabling ngrok persistence support, based on the https://github.com/bogdanovich/ngrok-tunnel/pull/11 by @scottmartinnet

Is now correctly working, launching ngrok as a background process if persistence key is present
