### PR TITLE
Add ngrok v3 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 *.a
 mkmf.log
 test.log
+TAGS

--- a/ngrok-tunnel.gemspec
+++ b/ngrok-tunnel.gemspec
@@ -18,9 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency("pry", "~> 0.10")
-  spec.add_development_dependency("pry-byebug", "~> 2.0")
+  spec.add_development_dependency("pry")
+  spec.add_development_dependency("pry-byebug")
   spec.add_development_dependency("rspec", "~> 3.1")
-  spec.add_development_dependency "bundler", "~> 1.7"
-  spec.add_development_dependency "rake", "~> 10.0"
 end

--- a/spec/tunnel/tunnel_spec.rb
+++ b/spec/tunnel/tunnel_spec.rb
@@ -41,8 +41,8 @@ describe Ngrok::Tunnel do
       expect(Ngrok::Tunnel.addr).to eq(3001)
     end
 
-    it "has valid ngrok_url" do
-      expect(Ngrok::Tunnel.ngrok_url).to be =~ /http:\/\/.*ngrok\.io$/
+    it "has nil ngrok_url" do
+      expect(Ngrok::Tunnel.ngrok_url).to be nil
     end
 
     it "has valid ngrok_url_https" do
@@ -67,32 +67,25 @@ describe Ngrok::Tunnel do
 
   describe "Custom subdomain" do
     it "fails without authtoken" do
-      expect {Ngrok::Tunnel.start(subdomain: 'test-subdomain')}.to raise_error Ngrok::Error
+      expect {Ngrok::Tunnel.start(subdomain: 'test-subdomain', redirect_stderr: true)}.to raise_error Ngrok::Error
     end
 
     it "fails with incorrect authtoken" do
-      expect {Ngrok::Tunnel.start(subdomain: 'test-subdomain', authtoken: 'incorrect_token')}.to raise_error Ngrok::Error
+      expect {Ngrok::Tunnel.start(subdomain: 'test-subdomain', authtoken: 'incorrect_token', redirect_stderr: true)}.to raise_error Ngrok::Error
     end
   end
 
   describe "Custom hostname" do
     it "fails without authtoken" do
-      expect {Ngrok::Tunnel.start(hostname: 'example.com')}.to raise_error Ngrok::Error
+      expect {Ngrok::Tunnel.start(hostname: 'example.com', redirect_stderr: true)}.to raise_error Ngrok::Error
     end
 
     it "fails with incorrect authtoken" do
-      expect {Ngrok::Tunnel.start(hostname: 'example.com', authtoken: 'incorrect_token')}.to raise_error Ngrok::Error
+      expect {Ngrok::Tunnel.start(hostname: 'example.com', authtoken: 'incorrect_token', redirect_stderr: true)}.to raise_error Ngrok::Error
     end
   end
 
   describe "Custom addr" do
-    it "maps port param to addr" do
-      port = 10010
-      Ngrok::Tunnel.start(port: port)
-      expect(Ngrok::Tunnel.addr).to eq port
-      Ngrok::Tunnel.stop
-    end
-
     it "returns just the port when the address contains a host" do
       addr = '192.168.0.5:10010'
       Ngrok::Tunnel.start(addr: addr)
@@ -109,71 +102,72 @@ describe Ngrok::Tunnel do
   end
 
   describe "Custom region" do
-    it "doesn't include the -region parameter when it is not provided" do
+    it "doesn't include the --region parameter when it is not provided" do
       Ngrok::Tunnel.start()
-      expect(Ngrok::Tunnel.send(:ngrok_exec_params)).not_to include("-region=")
+      expect(Ngrok::Tunnel.send(:ngrok_exec_params)).not_to include("--region=")
       Ngrok::Tunnel.stop
     end
 
-    it "includes the -region parameter with the correct value when it is provided" do
+    it "includes the --region parameter with the correct value when it is provided" do
       region = 'eu'
       Ngrok::Tunnel.start(region: region)
-      expect(Ngrok::Tunnel.send(:ngrok_exec_params)).to include("-region=#{region}")
+      expect(Ngrok::Tunnel.send(:ngrok_exec_params)).to include("--region=#{region}")
       Ngrok::Tunnel.stop
     end
   end
 
-  describe "Custom bind-tls" do
-    it "doesn't include the -bind-tls parameter when it is not provided" do
+  describe "Custom --scheme" do
+    it "doesn't include the --scheme parameter when it is not provided" do
       Ngrok::Tunnel.start()
-      expect(Ngrok::Tunnel.send(:ngrok_exec_params)).not_to include("-bind-tls=")
+      expect(Ngrok::Tunnel.send(:ngrok_exec_params)).not_to include("--scheme=")
       Ngrok::Tunnel.stop
     end
 
-    it "includes the -bind-tls parameter with the correct value when it is true" do
-      bind_tls = true
-      Ngrok::Tunnel.start(bind_tls: bind_tls)
-      expect(Ngrok::Tunnel.send(:ngrok_exec_params)).to include("-bind-tls=#{bind_tls}")
+    it "includes the --scheme parameter with the correct value when it is https" do
+      scheme = "https"
+      Ngrok::Tunnel.start(scheme: scheme)
+      expect(Ngrok::Tunnel.send(:ngrok_exec_params)).to include("--scheme=#{scheme}")
       Ngrok::Tunnel.stop
     end
 
-    it "includes the -bind-tls parameter with the correct value when it is false" do
-      bind_tls = false
-      Ngrok::Tunnel.start(bind_tls: bind_tls)
-      expect(Ngrok::Tunnel.send(:ngrok_exec_params)).to include("-bind-tls=#{bind_tls}")
+    it "includes the --scheme parameter with the correct value when it is http" do
+      scheme = "http"
+      Ngrok::Tunnel.start(scheme: scheme)
+      expect(Ngrok::Tunnel.send(:ngrok_exec_params)).to include("--scheme=#{scheme}")
+      expect(Ngrok::Tunnel.ngrok_url).to be =~ /http:\/\/.*ngrok\.io$/
       Ngrok::Tunnel.stop
     end
   end
 
   describe "Custom host header" do
-    it "doesn't include the -host-header parameter when it is not provided" do
+    it "doesn't include the --host-header parameter when it is not provided" do
       Ngrok::Tunnel.start()
-      expect(Ngrok::Tunnel.send(:ngrok_exec_params)).not_to include("-host-header=")
+      expect(Ngrok::Tunnel.send(:ngrok_exec_params)).not_to include("--host-header=")
       Ngrok::Tunnel.stop
     end
 
-    it "includes the -host-header parameter with the correct value when it is provided" do
+    it "includes the --host-header parameter with the correct value when it is provided" do
       host_header = 'foo.bar'
       Ngrok::Tunnel.start(host_header: host_header)
-      expect(Ngrok::Tunnel.send(:ngrok_exec_params)).to include("-host-header=#{host_header}")
+      expect(Ngrok::Tunnel.send(:ngrok_exec_params)).to include("--host-header=#{host_header}")
       Ngrok::Tunnel.stop
     end
   end
 
   describe "Custom parameters provided" do
-    it "doesn't include the -inspect parameter when it is not provided" do
+    it "doesn't include the --inspect parameter when it is not provided" do
       Ngrok::Tunnel.start()
-      expect(Ngrok::Tunnel.send(:ngrok_exec_params)).not_to include("-inspect=")
+      expect(Ngrok::Tunnel.send(:ngrok_exec_params)).not_to include("--inspect=")
       Ngrok::Tunnel.stop
     end
 
-    it "includes the -inspect parameter with the correct value when it is provided" do
+    it "includes the --inspect parameter with the correct value when it is provided" do
       Ngrok::Tunnel.start(inspect: true)
-      expect(Ngrok::Tunnel.send(:ngrok_exec_params)).to include("-inspect=true")
+      expect(Ngrok::Tunnel.send(:ngrok_exec_params)).to include("--inspect=true")
       Ngrok::Tunnel.stop
 
       Ngrok::Tunnel.start(inspect: false)
-      expect(Ngrok::Tunnel.send(:ngrok_exec_params)).to include("-inspect=false")
+      expect(Ngrok::Tunnel.send(:ngrok_exec_params)).to include("--inspect=false")
       Ngrok::Tunnel.stop
     end
   end


### PR DESCRIPTION
This PR adds support for ngrok v3.

However, [enough changed](https://ngrok.com/docs/guides/upgrade-v2-v3) that I decided to drop support for older versions of ngrok, and instead prompt the user to upgrade ngrok if a pre-v3 version is detected.

This PR also cleans up the gemspec so I could run specs, and adds support for redirecting stderr so I could get a clean spec output (see screenshot).

<img width="520" alt="image" src="https://user-images.githubusercontent.com/6880880/165225567-4b9ea011-5b53-42c3-8671-6747d6f2b325.png">

Note: It would be amazing if this PR is accepted and the gem published with a new version - however, in the meantime, I'll likely run this version by referring directly to the commit id in my application's gemfile:
```
gem "ngrok-tunnel", github: "GetJobber/ngrok-tunnel", ref: "c2bf7dd"
```